### PR TITLE
Add new `DisjointSet#includes(value)` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -12,6 +12,10 @@ class DisjointSet {
   _id(x) {
     return x;
   }
+
+  includes(value) {
+    return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
+  }
 }
 
 module.exports = DisjointSet;

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -3,7 +3,9 @@ declare namespace disjointSet {
     new <T = any>(): Instance<T>;
   }
 
-  export interface Instance<T> {}
+  export interface Instance<T> {
+    includes(value: T): boolean;
+  }
 }
 
 declare namespace dsforest {


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `DisjointSet#includes(value)`

Determines whether the given element `value` is part of a set, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
