### PR TITLE
Add new `DisjointSet#makeSet(value)` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -16,6 +16,18 @@ class DisjointSet {
   includes(value) {
     return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
   }
+
+  makeSet(value) {
+    if (!this.includes(value)) {
+      const id = this._idAccessorFn(value);
+      this._parent[id] = value;
+      this._rank[id] = 0;
+      this._size[id] = 1;
+      this._sets += 1;
+    }
+
+    return this;
+  }
 }
 
 module.exports = DisjointSet;

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -5,6 +5,7 @@ declare namespace disjointSet {
 
   export interface Instance<T> {
     includes(value: T): boolean;
+    makeSet(value: T): this;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `DisjointSet#makeSet(value)`

Mutates the disjoint-set forest by creating a new singleton set containing the element `value` with a rank of 0, a parent pointer to itself, indicating that the element is the representative member of its own set and a corresponding unique id. Returns the disjoint-set forest itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.