### PR TITLE
Add new `DisjointSet#forestSize` class property accessor (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -13,6 +13,10 @@ class DisjointSet {
     return x;
   }
 
+  get forestSize() {
+    return this._sets;
+  }
+
   includes(value) {
     return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
   }

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -4,6 +4,7 @@ declare namespace disjointSet {
   }
 
   export interface Instance<T> {
+    readonly forestSize: number;
     includes(value: T): boolean;
     makeSet(value: T): this;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new property accessor: 

- `DisjointSet#forestSize`

Returns the number of disjoint sets in the forest.

Also, the corresponding TypeScript ambient declarations are included in the PR.