### PR TITLE
Add new `DisjointSet#forestElements` class property accessor (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -17,6 +17,10 @@ class DisjointSet {
     return this._sets;
   }
 
+  get forestElements() {
+    return Object.keys(this._parent).length;
+  }
+
   includes(value) {
     return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
   }

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -4,6 +4,7 @@ declare namespace disjointSet {
   }
 
   export interface Instance<T> {
+    readonly forestElements: number;
     readonly forestSize: number;
     includes(value: T): boolean;
     makeSet(value: T): this;


### PR DESCRIPTION
## Description

The PR introduces the following new property accessor: 

- `DisjointSet#forestElements`

Returns the total number of all elements among the disjoint sets of the forest.

Also, the corresponding TypeScript ambient declarations are included in the PR.