### PR TITLE
Add new `DisjointSet#findSet(value)` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -9,6 +9,16 @@ class DisjointSet {
     this._idAccessorFn = idAccessorFn || this._id;
   }
 
+  _findSet(value) {
+    const id = this._idAccessorFn(value);
+
+    if (this._parent[id] !== value) {
+      this._parent[id] = this._findSet(this._parent[id]);
+    }
+
+    return this._parent[id];
+  }
+
   _id(x) {
     return x;
   }
@@ -19,6 +29,14 @@ class DisjointSet {
 
   get forestSets() {
     return this._sets;
+  }
+
+  findSet(value) {
+    if (this.includes(value)) {
+      return this._findSet(value);
+    }
+
+    return undefined;
   }
 
   includes(value) {

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -6,6 +6,7 @@ declare namespace disjointSet {
   export interface Instance<T> {
     readonly forestElements: number;
     readonly forestSets: number;
+    findSet(value: T): T | undefined;
     includes(value: T): boolean;
     makeSet(value: T): this;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `DisjointSet#findSet(value)`

Returns the representative element of the disjoint set that element `value` is part of. If the given element is not part of any set, then `undefined` is returned. The method uses the **path compression** heuristic which mutates the parent pointer of each element, part of the find path, by making it point directly to the set representative.

Also, the corresponding TypeScript ambient declarations are included in the PR.