### PR TITLE
Add new `DisjointSet#areConnected(x, y)` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -43,6 +43,14 @@ class DisjointSet {
     return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
   }
 
+  areConnected(x, y) {
+    if (!this.includes(x) || !this.includes(y)) {
+      return false;
+    }
+
+    return this._findSet(x) === this._findSet(y);
+  }
+
   makeSet(value) {
     if (!this.includes(value)) {
       const id = this._idAccessorFn(value);

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -6,6 +6,7 @@ declare namespace disjointSet {
   export interface Instance<T> {
     readonly forestElements: number;
     readonly forestSets: number;
+    areConnected(x: T, y: T): boolean;
     findSet(value: T): T | undefined;
     includes(value: T): boolean;
     makeSet(value: T): this;


### PR DESCRIPTION
## Description

The PR introduces the following new binary predicate method: 

- `DisjointSet#areConnected(x, y)`

Determines whether the two given elements `x` and `y` belong to the same disjoint set, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.