### PR TITLE
Add new `DisjointSet#isEmpty()` predicate class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -31,6 +31,14 @@ class DisjointSet {
     return this._sets;
   }
 
+  areConnected(x, y) {
+    if (!this.includes(x) || !this.includes(y)) {
+      return false;
+    }
+
+    return this._findSet(x) === this._findSet(y);
+  }
+
   findSet(value) {
     if (this.includes(value)) {
       return this._findSet(value);
@@ -43,12 +51,8 @@ class DisjointSet {
     return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
   }
 
-  areConnected(x, y) {
-    if (!this.includes(x) || !this.includes(y)) {
-      return false;
-    }
-
-    return this._findSet(x) === this._findSet(y);
+  isEmpty() {
+    return this.forestElements === 0;
   }
 
   makeSet(value) {

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -9,6 +9,7 @@ declare namespace disjointSet {
     areConnected(x: T, y: T): boolean;
     findSet(value: T): T | undefined;
     includes(value: T): boolean;
+    isEmpty(): boolean;
     makeSet(value: T): this;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary predicate method: 

- `DisjointSet#isEmpty()`

Determines whether the foreset contains any elements, thus any disjoint sets, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.