### PR TITLE
Add new `DisjointSet#setSize(value)` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -66,6 +66,14 @@ class DisjointSet {
 
     return this;
   }
+
+  setSize(value) {
+    if (!this.includes(value)) {
+      return 0;
+    }
+
+    return this._size[this._idAccessorFn(this._findSet(value))];
+  }
 }
 
 module.exports = DisjointSet;

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -11,6 +11,7 @@ declare namespace disjointSet {
     includes(value: T): boolean;
     isEmpty(): boolean;
     makeSet(value: T): this;
+    setSize(value: T): number;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `DisjointSet#setSize(value)`

Returns the size of the disjoint set that the given element `value` is a member of. If the value is not part of any set, then `0` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.