### PR TITLE
Add new `DisjointSet#isSingleton(value)` predicate class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -55,6 +55,10 @@ class DisjointSet {
     return this.forestElements === 0;
   }
 
+  isSingleton(value) {
+    return this._size[this._idAccessorFn(value)] === 1;
+  }
+
   makeSet(value) {
     if (!this.includes(value)) {
       const id = this._idAccessorFn(value);

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -10,6 +10,7 @@ declare namespace disjointSet {
     findSet(value: T): T | undefined;
     includes(value: T): boolean;
     isEmpty(): boolean;
+    isSingleton(value: T): boolean;
     makeSet(value: T): this;
     setSize(value: T): number;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `DisjointSet#isSingleton(value)`

Determines whether the given element `value` is part of a singleton disjoint-set, a set of size `1` with `value` as its representative element, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.