### PR TITLE
Add new `DisjointSet#isRepresentative(value)` predicate class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -55,6 +55,14 @@ class DisjointSet {
     return this.forestElements === 0;
   }
 
+  isRepresentative(value) {
+    if (!this.includes(value)) {
+      return false;
+    }
+
+    return this._parent[this._idAccessorFn(value)] === value;
+  }
+
   isSingleton(value) {
     return this._size[this._idAccessorFn(value)] === 1;
   }

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -10,6 +10,7 @@ declare namespace disjointSet {
     findSet(value: T): T | undefined;
     includes(value: T): boolean;
     isEmpty(): boolean;
+    isRepresentative(value: T): boolean;
     isSingleton(value: T): boolean;
     makeSet(value: T): this;
     setSize(value: T): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `DisjointSet#isRepresentative(value)`

Determines whether the given element `value` is the representative element of its disjoint-set, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.