### PR TITLE
Add new `DisjointSet#union(x, y)` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -86,6 +86,33 @@ class DisjointSet {
 
     return this._size[this._idAccessorFn(this._findSet(value))];
   }
+
+  union(x, y) {
+    if (this.includes(x) && this.includes(y)) {
+      let xRep = this._findSet(x);
+      let yRep = this._findSet(y);
+
+      if (xRep !== yRep) {
+        let xRepId = this._idAccessorFn(xRep);
+        let yRepId = this._idAccessorFn(yRep);
+        const rankDiff = this._rank[xRepId] - this._rank[yRepId];
+
+        if (rankDiff === 0) {
+          this._rank[xRepId] += 1;
+        } else if (rankDiff < 0) {
+          [xRep, yRep] = [yRep, xRep];
+          [xRepId, yRepId] = [yRepId, xRepId];
+        }
+
+        this._parent[yRepId] = xRep;
+        this._size[xRepId] += this._size[yRepId];
+        delete this._size[yRepId];
+        this._sets -= 1;
+      }
+    }
+
+    return this;
+  }
 }
 
 module.exports = DisjointSet;

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -14,6 +14,7 @@ declare namespace disjointSet {
     isSingleton(value: T): boolean;
     makeSet(value: T): this;
     setSize(value: T): number;
+    union(x: T, y: T): this;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new binary method: 

- `DisjointSet#union(x, y)`

Determines the set representatives/roots of the given `x` and `y` elements, and if they are distinct, the sets/trees that `x` and `y` belong to are merged by updating the parent pointer of the set representative/root with the lower rank to point to the set representative/root with the higher rank. If instead, the representatives/roots have equal ranks, the set representative/root of element `x` is chosen **by default** as the parent of the `y` element representative/root, while its rank is also incremented. Returns the disjoint-set forest itself. 

The method uses the **union by rank** heuristic which enable us to prevent the height growth of a disjoint-set/tree to `O(n)` levels, by always attaching the shorter tree to the root of the taller tree, thus the resulting tree is no taller than the originals unless they were of equal height, in which case the resulting tree is taller by one node.

Also, the corresponding TypeScript ambient declarations are included in the PR.