### PR TITLE
Add new `DisjointSet#getId(value)` class method. Fixes #3.

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -47,6 +47,14 @@ class DisjointSet {
     return undefined;
   }
 
+  getId(value) {
+    if (!this.includes(value)) {
+      return undefined;
+    }
+
+    return this._idAccessorFn(value);
+  }
+
   includes(value) {
     return Object.prototype.hasOwnProperty.call(this._parent, this._idAccessorFn(value));
   }

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -1,13 +1,14 @@
 declare namespace disjointSet {
   export interface Constructor {
-    new <T = any, U = T>(idAccessorFn?: (value: T) => U): Instance<T>;
+    new <T = any, U = T>(idAccessorFn?: (value: T) => U): Instance<T, U>;
   }
 
-  export interface Instance<T> {
+  export interface Instance<T, U> {
     readonly forestElements: number;
     readonly forestSets: number;
     areConnected(x: T, y: T): boolean;
     findSet(value: T): T | undefined;
+    getId(value: T): U | undefined;
     includes(value: T): boolean;
     isEmpty(): boolean;
     isRepresentative(value: T): boolean;
@@ -19,7 +20,8 @@ declare namespace disjointSet {
 }
 
 declare namespace dsforest {
-  export interface DisjointSet<T = any> extends disjointSet.Instance<T> {}
+  export interface DisjointSet<T = any, U = T>
+    extends disjointSet.Instance<T, U> {}
 }
 
 declare const dsforest: {


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `DisjointSet#getId(value)`

Returns the unique `id` that the given `value` element corresponds to and which is used as a key to point to the parent element of `value` in the `parent` associative array. If the given `value` element is not part of any disjoint-set, then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.