### PR TITLE
Add new `DisjointSet#clear()` class method (#3)

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -39,6 +39,14 @@ class DisjointSet {
     return this._findSet(x) === this._findSet(y);
   }
 
+  clear() {
+    this._parent = {};
+    this._rank = {};
+    this._size = {};
+    this._sets = 0;
+    return this;
+  }
+
   findSet(value) {
     if (this.includes(value)) {
       return this._findSet(value);

--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -7,6 +7,7 @@ declare namespace disjointSet {
     readonly forestElements: number;
     readonly forestSets: number;
     areConnected(x: T, y: T): boolean;
+    clear(): this;
     findSet(value: T): T | undefined;
     getId(value: T): U | undefined;
     includes(value: T): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `DisjointSet#clear()`

Mutates the disjoint-set forest instance by removing all residing elements and sets, returning it completely empty.

Also, the corresponding TypeScript ambient declarations are included in the PR.
