### PR TITLE
Replace `any` default type for generics with `unknown`

### DIFF
--- a/types/dsforest.d.ts
+++ b/types/dsforest.d.ts
@@ -1,6 +1,6 @@
 declare namespace disjointSet {
   export interface Constructor {
-    new <T = any, U = T>(idAccessorFn?: (value: T) => U): Instance<T, U>;
+    new <T = unknown, U = T>(idAccessorFn?: (value: T) => U): Instance<T, U>;
   }
 
   export interface Instance<T, U> {
@@ -21,7 +21,7 @@ declare namespace disjointSet {
 }
 
 declare namespace dsforest {
-  export interface DisjointSet<T = any, U = T>
+  export interface DisjointSet<T = unknown, U = T>
     extends disjointSet.Instance<T, U> {}
 }
 


### PR DESCRIPTION
## Description
The PR replaces the any type used as the default type for the generic type parameters with the more type-safe [unknown](https://devblogs.microsoft.com/typescript/announcing-typescript-3-0-rc-2/#the-unknown-type) type.